### PR TITLE
FE기반 todo구현완료

### DIFF
--- a/src/main/java/com/studiz/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/studiz/domain/auth/controller/AuthController.java
@@ -35,21 +35,11 @@ public class AuthController {
         RegisterResponse response = userService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
-
-    @PostMapping("/login")
-    @Operation(summary = "로그인", description = "사용자 로그인을 처리합니다.")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        log.info("로그인 요청: loginId={}", request.getLoginId());
-        LoginResponse response = userService.login(request);
-        return ResponseEntity.ok(response);
-    }
-}
-
-
+    
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "로그인 성공 시 JWT 토큰을 발급합니다.")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        log.info("로그인 요청: loginId={}", request.getLoginId());
         return ResponseEntity.ok(authService.login(request));
     }
 }

--- a/src/main/java/com/studiz/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/studiz/domain/auth/dto/LoginRequest.java
@@ -3,14 +3,13 @@ package com.studiz.domain.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-
 public class LoginRequest {
 
     @NotBlank(message = "아이디는 필수입니다.")
@@ -19,4 +18,3 @@ public class LoginRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }
-

--- a/src/main/java/com/studiz/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/studiz/domain/auth/dto/LoginResponse.java
@@ -42,4 +42,13 @@ public class LoginResponse {
                 .message("로그인 성공")
                 .build();
     }
+    
+    public static LoginResponse from(User user) {
+        return LoginResponse.builder()
+                .userId(user.getId())
+                .loginId(user.getLoginId())
+                .name(user.getName())
+                .message("로그인 성공")
+                .build();
+    }
 }

--- a/src/main/java/com/studiz/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/studiz/domain/todo/controller/TodoController.java
@@ -1,0 +1,62 @@
+package com.studiz.domain.todo.controller;
+
+import com.studiz.domain.todo.dto.TodoCompleteRequest;
+import com.studiz.domain.todo.dto.TodoCreateRequest;
+import com.studiz.domain.todo.dto.TodoDetailResponse;
+import com.studiz.domain.todo.dto.TodoResponse;
+import com.studiz.domain.todo.service.TodoService;
+import com.studiz.domain.user.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/studies/{studyId}/todos")
+@RequiredArgsConstructor
+public class TodoController {
+    
+    private final TodoService todoService;
+    
+    @PostMapping
+    public ResponseEntity<TodoDetailResponse> createTodo(
+            @PathVariable UUID studyId,
+            @Valid @RequestBody TodoCreateRequest request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(todoService.createTodo(studyId, request, userPrincipal.getUser()));
+    }
+    
+    @GetMapping
+    public ResponseEntity<List<TodoResponse>> getTodos(
+            @PathVariable UUID studyId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(todoService.getTodos(studyId, userPrincipal.getUser()));
+    }
+    
+    @GetMapping("/{todoId}")
+    public ResponseEntity<TodoDetailResponse> getTodoDetail(
+            @PathVariable UUID studyId,
+            @PathVariable UUID todoId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(todoService.getTodoDetail(studyId, todoId, userPrincipal.getUser()));
+    }
+    
+    @PatchMapping("/{todoId}/complete")
+    public ResponseEntity<String> completeTodo(
+            @PathVariable UUID studyId,
+            @PathVariable UUID todoId,
+            @Valid @RequestBody TodoCompleteRequest request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        todoService.completeTodo(studyId, todoId, userPrincipal.getUser(), request);
+        return ResponseEntity.ok("할 일이 완료되었습니다.");
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/dto/TodoCompleteRequest.java
+++ b/src/main/java/com/studiz/domain/todo/dto/TodoCompleteRequest.java
@@ -1,0 +1,13 @@
+package com.studiz.domain.todo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TodoCompleteRequest {
+    
+    @NotBlank(message = "인증 내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/studiz/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/studiz/domain/todo/dto/TodoCreateRequest.java
@@ -1,0 +1,35 @@
+package com.studiz.domain.todo.dto;
+
+import com.studiz.domain.todo.entity.TodoCertificationType;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class TodoCreateRequest {
+    
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 100, message = "이름은 100자 이하여야 합니다.")
+    private String name;
+    
+    @Size(max = 1000, message = "설명은 1000자 이하여야 합니다.")
+    private String description;
+    
+    @NotNull(message = "마감일은 필수입니다.")
+    @Future(message = "마감일은 현재 이후여야 합니다.")
+    private LocalDateTime dueDate;
+    
+    @NotNull(message = "인증 방식은 필수입니다.")
+    private TodoCertificationType certificationType;
+    
+    @NotEmpty(message = "참여자는 최소 1명 이상이어야 합니다.")
+    private List<Long> participantIds;
+}

--- a/src/main/java/com/studiz/domain/todo/dto/TodoDetailResponse.java
+++ b/src/main/java/com/studiz/domain/todo/dto/TodoDetailResponse.java
@@ -1,0 +1,26 @@
+package com.studiz.domain.todo.dto;
+
+import com.studiz.domain.todo.entity.Todo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TodoDetailResponse {
+    
+    private final TodoResponse todo;
+    private final List<TodoMemberResponse> members;
+    
+    public static TodoDetailResponse from(Todo todo) {
+        return TodoDetailResponse.builder()
+                .todo(TodoResponse.from(todo))
+                .members(todo.getMembers()
+                        .stream()
+                        .map(TodoMemberResponse::from)
+                        .toList())
+                .build();
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/dto/TodoMemberResponse.java
+++ b/src/main/java/com/studiz/domain/todo/dto/TodoMemberResponse.java
@@ -1,0 +1,33 @@
+package com.studiz.domain.todo.dto;
+
+import com.studiz.domain.todo.entity.TodoMember;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TodoMemberResponse {
+    
+    private final Long memberId;
+    private final Long userId;
+    private final String loginId;
+    private final String name;
+    private final boolean completed;
+    private final LocalDateTime completedAt;
+    private final String certificationContent;
+    
+    public static TodoMemberResponse from(TodoMember member) {
+        return TodoMemberResponse.builder()
+                .memberId(member.getId())
+                .userId(member.getUser().getId())
+                .loginId(member.getUser().getLoginId())
+                .name(member.getUser().getName())
+                .completed(member.isCompleted())
+                .completedAt(member.getCompletedAt())
+                .certificationContent(member.getCertificationContent())
+                .build();
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/com/studiz/domain/todo/dto/TodoResponse.java
@@ -1,0 +1,42 @@
+package com.studiz.domain.todo.dto;
+
+import com.studiz.domain.todo.entity.Todo;
+import com.studiz.domain.todo.entity.TodoStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class TodoResponse {
+    
+    private final UUID id;
+    private final String name;
+    private final String description;
+    private final LocalDateTime dueDate;
+    private final String certificationType;
+    private final TodoStatus status;
+    private final int completedCount;
+    private final int totalCount;
+    
+    public static TodoResponse from(Todo todo) {
+        int total = todo.getMembers().size();
+        int completed = (int) todo.getMembers().stream()
+                .filter(member -> member.isCompleted())
+                .count();
+        
+        return TodoResponse.builder()
+                .id(todo.getId())
+                .name(todo.getName())
+                .description(todo.getDescription())
+                .dueDate(todo.getDueDate())
+                .certificationType(todo.getCertificationType().name())
+                .status(todo.getStatus())
+                .completedCount(completed)
+                .totalCount(total)
+                .build();
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/entity/Todo.java
+++ b/src/main/java/com/studiz/domain/todo/entity/Todo.java
@@ -1,0 +1,77 @@
+package com.studiz.domain.todo.entity;
+
+import com.studiz.domain.study.entity.Study;
+import com.studiz.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "todos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Todo extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @Column(nullable = false)
+    private LocalDateTime dueDate;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TodoCertificationType certificationType;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private TodoStatus status = TodoStatus.ACTIVE;
+    
+    @OneToMany(mappedBy = "todo", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<TodoMember> members = new ArrayList<>();
+    
+    public static Todo create(Study study,
+                              String name,
+                              String description,
+                              LocalDateTime dueDate,
+                              TodoCertificationType certificationType) {
+        return Todo.builder()
+                .study(study)
+                .name(name)
+                .description(description)
+                .dueDate(dueDate)
+                .certificationType(certificationType)
+                .status(TodoStatus.ACTIVE)
+                .build();
+    }
+    
+    public void addMember(TodoMember member) {
+        this.members.add(member);
+    }
+    
+    public void markCompleted() {
+        this.status = TodoStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/studiz/domain/todo/entity/TodoCertificationType.java
+++ b/src/main/java/com/studiz/domain/todo/entity/TodoCertificationType.java
@@ -1,0 +1,7 @@
+package com.studiz.domain.todo.entity;
+
+public enum TodoCertificationType {
+    FILE_UPLOAD,
+    TEXT_NOTE
+}
+

--- a/src/main/java/com/studiz/domain/todo/entity/TodoMember.java
+++ b/src/main/java/com/studiz/domain/todo/entity/TodoMember.java
@@ -1,0 +1,57 @@
+package com.studiz.domain.todo.entity;
+
+import com.studiz.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "todo_members",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"todo_id", "user_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TodoMember {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_id", nullable = false)
+    private Todo todo;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @Column(columnDefinition = "TEXT")
+    private String certificationContent;
+    
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean completed = false;
+    
+    private LocalDateTime completedAt;
+    
+    public static TodoMember assign(Todo todo, User user) {
+        return TodoMember.builder()
+                .todo(todo)
+                .user(user)
+                .completed(false)
+                .build();
+    }
+    
+    public void complete(String content) {
+        this.certificationContent = content;
+        this.completed = true;
+        this.completedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/entity/TodoStatus.java
+++ b/src/main/java/com/studiz/domain/todo/entity/TodoStatus.java
@@ -1,0 +1,7 @@
+package com.studiz.domain.todo.entity;
+
+public enum TodoStatus {
+    ACTIVE,
+    COMPLETED
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoAlreadyCompletedException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoAlreadyCompletedException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoAlreadyCompletedException extends CustomException {
+    
+    public TodoAlreadyCompletedException() {
+        super(ErrorCode.TODO_ALREADY_COMPLETED);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoCertificationRequiredException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoCertificationRequiredException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoCertificationRequiredException extends CustomException {
+    
+    public TodoCertificationRequiredException() {
+        super(ErrorCode.TODO_CERTIFICATION_REQUIRED);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoInvalidParticipantException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoInvalidParticipantException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoInvalidParticipantException extends CustomException {
+    
+    public TodoInvalidParticipantException() {
+        super(ErrorCode.TODO_INVALID_PARTICIPANT);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoMemberForbiddenException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoMemberForbiddenException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoMemberForbiddenException extends CustomException {
+    
+    public TodoMemberForbiddenException() {
+        super(ErrorCode.TODO_MEMBER_FORBIDDEN);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoNotFoundException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoNotFoundException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoNotFoundException extends CustomException {
+    
+    public TodoNotFoundException() {
+        super(ErrorCode.TODO_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/exception/TodoParticipantRequiredException.java
+++ b/src/main/java/com/studiz/domain/todo/exception/TodoParticipantRequiredException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.todo.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class TodoParticipantRequiredException extends CustomException {
+    
+    public TodoParticipantRequiredException() {
+        super(ErrorCode.TODO_PARTICIPANT_REQUIRED);
+    }
+}
+

--- a/src/main/java/com/studiz/domain/todo/repository/TodoMemberRepository.java
+++ b/src/main/java/com/studiz/domain/todo/repository/TodoMemberRepository.java
@@ -1,0 +1,19 @@
+package com.studiz.domain.todo.repository;
+
+import com.studiz.domain.todo.entity.Todo;
+import com.studiz.domain.todo.entity.TodoMember;
+import com.studiz.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TodoMemberRepository extends JpaRepository<TodoMember, Long> {
+    
+    Optional<TodoMember> findByTodoAndUser(Todo todo, User user);
+    
+    long countByTodoAndCompletedFalse(Todo todo);
+    
+    List<TodoMember> findByTodo(Todo todo);
+}
+

--- a/src/main/java/com/studiz/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/studiz/domain/todo/repository/TodoRepository.java
@@ -1,0 +1,17 @@
+package com.studiz.domain.todo.repository;
+
+import com.studiz.domain.study.entity.Study;
+import com.studiz.domain.todo.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TodoRepository extends JpaRepository<Todo, UUID> {
+    
+    List<Todo> findByStudyOrderByDueDateAsc(Study study);
+    
+    Optional<Todo> findByIdAndStudy(UUID id, Study study);
+}
+

--- a/src/main/java/com/studiz/domain/todo/service/TodoService.java
+++ b/src/main/java/com/studiz/domain/todo/service/TodoService.java
@@ -1,0 +1,125 @@
+package com.studiz.domain.todo.service;
+
+import com.studiz.domain.study.entity.Study;
+import com.studiz.domain.study.service.StudyService;
+import com.studiz.domain.studymember.repository.StudyMemberRepository;
+import com.studiz.domain.studymember.service.StudyMemberService;
+import com.studiz.domain.todo.dto.TodoCompleteRequest;
+import com.studiz.domain.todo.dto.TodoCreateRequest;
+import com.studiz.domain.todo.dto.TodoDetailResponse;
+import com.studiz.domain.todo.dto.TodoResponse;
+import com.studiz.domain.todo.entity.Todo;
+import com.studiz.domain.todo.entity.TodoMember;
+import com.studiz.domain.todo.exception.*;
+import com.studiz.domain.todo.repository.TodoMemberRepository;
+import com.studiz.domain.todo.repository.TodoRepository;
+import com.studiz.domain.user.entity.User;
+import com.studiz.domain.user.exception.UserNotFoundException;
+import com.studiz.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TodoService {
+    
+    private final TodoRepository todoRepository;
+    private final TodoMemberRepository todoMemberRepository;
+    private final StudyService studyService;
+    private final StudyMemberService studyMemberService;
+    private final StudyMemberRepository studyMemberRepository;
+    private final UserRepository userRepository;
+    
+    public TodoDetailResponse createTodo(UUID studyId, TodoCreateRequest request, User owner) {
+        Study study = studyService.getStudy(studyId);
+        studyMemberService.ensureOwner(study, owner);
+        
+        if (CollectionUtils.isEmpty(request.getParticipantIds())) {
+            throw new TodoParticipantRequiredException();
+        }
+        
+        List<User> participants = request.getParticipantIds().stream()
+                .distinct()
+                .map(this::getUser)
+                .collect(Collectors.toList());
+        
+        participants.forEach(user -> studyMemberRepository.findByStudyAndUser(study, user)
+                .orElseThrow(TodoInvalidParticipantException::new));
+        
+        Todo todo = Todo.create(
+                study,
+                request.getName(),
+                request.getDescription(),
+                request.getDueDate(),
+                request.getCertificationType()
+        );
+        
+        participants.forEach(user -> {
+            TodoMember member = TodoMember.assign(todo, user);
+            todo.addMember(member);
+        });
+        
+        Todo saved = todoRepository.save(todo);
+        return TodoDetailResponse.from(saved);
+    }
+    
+    @Transactional(readOnly = true)
+    public List<TodoResponse> getTodos(UUID studyId, User user) {
+        Study study = studyService.getStudy(studyId);
+        studyMemberService.ensureMember(study, user);
+        return todoRepository.findByStudyOrderByDueDateAsc(study).stream()
+                .map(TodoResponse::from)
+                .toList();
+    }
+    
+    @Transactional(readOnly = true)
+    public TodoDetailResponse getTodoDetail(UUID studyId, UUID todoId, User user) {
+        Study study = studyService.getStudy(studyId);
+        studyMemberService.ensureMember(study, user);
+        Todo todo = getTodo(study, todoId);
+        return TodoDetailResponse.from(todo);
+    }
+    
+    public void completeTodo(UUID studyId, UUID todoId, User user, TodoCompleteRequest request) {
+        Study study = studyService.getStudy(studyId);
+        studyMemberService.ensureMember(study, user);
+        Todo todo = getTodo(study, todoId);
+        
+        TodoMember todoMember = todoMemberRepository.findByTodoAndUser(todo, user)
+                .orElseThrow(TodoMemberForbiddenException::new);
+        
+        if (todoMember.isCompleted()) {
+            throw new TodoAlreadyCompletedException();
+        }
+        
+        if (!StringUtils.hasText(request.getContent())) {
+            throw new TodoCertificationRequiredException();
+        }
+        
+        todoMember.complete(request.getContent());
+        todoMemberRepository.save(todoMember);
+        
+        long remaining = todoMemberRepository.countByTodoAndCompletedFalse(todo);
+        if (remaining == 0) {
+            todo.markCompleted();
+        }
+    }
+    
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+    
+    private Todo getTodo(Study study, UUID todoId) {
+        return todoRepository.findByIdAndStudy(todoId, study)
+                .orElseThrow(TodoNotFoundException::new);
+    }
+}

--- a/src/main/java/com/studiz/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/studiz/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,12 @@
+package com.studiz.domain.user.exception;
+
+import com.studiz.global.exception.CustomException;
+import com.studiz.global.exception.ErrorCode;
+
+public class UserNotFoundException extends CustomException {
+    
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}
+

--- a/src/main/java/com/studiz/global/exception/ErrorCode.java
+++ b/src/main/java/com/studiz/global/exception/ErrorCode.java
@@ -25,6 +25,14 @@ public enum ErrorCode {
     STUDY_OWNER_CANNOT_BE_REMOVED(HttpStatus.BAD_REQUEST, "스터디장은 강퇴할 수 없습니다."),
     STUDY_MEMBER_ALREADY_OWNER(HttpStatus.BAD_REQUEST, "이미 스터디장 권한을 가진 멤버입니다."),
     
+    // Todo
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "할 일을 찾을 수 없습니다."),
+    TODO_PARTICIPANT_REQUIRED(HttpStatus.BAD_REQUEST, "할 일 참여자는 최소 한 명 이상이어야 합니다."),
+    TODO_INVALID_PARTICIPANT(HttpStatus.BAD_REQUEST, "스터디 멤버만 할 일에 참여할 수 있습니다."),
+    TODO_MEMBER_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 할 일의 참가자가 아닙니다."),
+    TODO_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 할 일입니다."),
+    TODO_CERTIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "인증 내용이 필요합니다."),
+    
     // Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
     

--- a/src/test/java/com/studiz/domain/study/service/StudyServiceTest.java
+++ b/src/test/java/com/studiz/domain/study/service/StudyServiceTest.java
@@ -44,14 +44,12 @@ class StudyServiceTest {
                 .loginId("owner1")
                 .password("password")
                 .name("Owner")
-                .email("owner@example.com")
                 .build());
         
         member = userRepository.save(User.builder()
                 .loginId("member1")
                 .password("password")
                 .name("Member")
-                .email("member@example.com")
                 .build());
     }
     
@@ -113,4 +111,3 @@ class StudyServiceTest {
         assertThat(previousOwner.getRole()).isEqualTo(StudyMemberRole.MEMBER);
     }
 }
-

--- a/src/test/java/com/studiz/domain/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/studiz/domain/todo/service/TodoServiceTest.java
@@ -1,0 +1,104 @@
+package com.studiz.domain.todo.service;
+
+import com.studiz.domain.study.entity.Study;
+import com.studiz.domain.study.service.StudyService;
+import com.studiz.domain.studymember.service.StudyMemberService;
+import com.studiz.domain.todo.dto.TodoCompleteRequest;
+import com.studiz.domain.todo.dto.TodoCreateRequest;
+import com.studiz.domain.todo.dto.TodoDetailResponse;
+import com.studiz.domain.todo.dto.TodoResponse;
+import com.studiz.domain.todo.entity.TodoCertificationType;
+import com.studiz.domain.user.entity.User;
+import com.studiz.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class TodoServiceTest {
+    
+    @Autowired
+    private TodoService todoService;
+    
+    @Autowired
+    private StudyService studyService;
+    
+    @Autowired
+    private StudyMemberService studyMemberService;
+    
+    @Autowired
+    private UserRepository userRepository;
+    
+    private Study study;
+    private User owner;
+    private User participant;
+    
+    @BeforeEach
+    void setUp() {
+        owner = userRepository.save(User.builder()
+                .loginId("owner")
+                .password("password")
+                .name("Owner")
+                .build());
+        
+        participant = userRepository.save(User.builder()
+                .loginId("member")
+                .password("password")
+                .name("Member")
+                .build());
+        
+        study = studyService.createStudy("스터디", "설명", owner);
+        studyMemberService.joinStudy(study, participant);
+    }
+    
+    @Test
+    @DisplayName("스터디장은 투두를 생성하고 조회할 수 있다")
+    void createTodo() {
+        TodoCreateRequest request = new TodoCreateRequest();
+        request.setName("자료 조사");
+        request.setDescription("다음 모임 전까지 조사");
+        request.setDueDate(LocalDateTime.now().plusDays(2));
+        request.setCertificationType(TodoCertificationType.TEXT_NOTE);
+        request.setParticipantIds(List.of(participant.getId()));
+        
+        TodoDetailResponse response = todoService.createTodo(study.getId(), request, owner);
+        assertThat(response.getTodo().getName()).isEqualTo("자료 조사");
+        assertThat(response.getMembers()).hasSize(1);
+        
+        List<TodoResponse> todos = todoService.getTodos(study.getId(), owner);
+        assertThat(todos).hasSize(1);
+        assertThat(todos.get(0).getCompletedCount()).isZero();
+    }
+    
+    @Test
+    @DisplayName("참여자는 자신의 투두를 완료할 수 있다")
+    void completeTodo() {
+        TodoCreateRequest request = new TodoCreateRequest();
+        request.setName("자료 조사");
+        request.setDescription("다음 모임 전까지 조사");
+        request.setDueDate(LocalDateTime.now().plusDays(2));
+        request.setCertificationType(TodoCertificationType.TEXT_NOTE);
+        request.setParticipantIds(List.of(participant.getId()));
+        
+        TodoDetailResponse detail = todoService.createTodo(study.getId(), request, owner);
+        UUID todoId = detail.getTodo().getId();
+        
+        TodoCompleteRequest completeRequest = new TodoCompleteRequest();
+        completeRequest.setContent("조사 완료");
+        todoService.completeTodo(study.getId(), todoId, participant, completeRequest);
+        
+        TodoDetailResponse after = todoService.getTodoDetail(study.getId(), todoId, owner);
+        assertThat(after.getTodo().getCompletedCount()).isEqualTo(1);
+        assertThat(after.getTodo().getStatus().name()).isEqualTo("COMPLETED");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
close #7 


## 🔨 작업 내용
<!-- 이번 PR에서 작업한 내용을 간단히 요약해주세요 -->
FE기반 todo리스트 구현 

## 📝 상세 설명
<!-- 작업한 내용에 대해 상세히 설명해주세요 -->
스터디장만 생성/삭제 가능

스터디 멤버만 조회 가능

참여 멤버만 완료 처리 가능

완료 비율 = 인증 완료 인원 / 참여 인원

전체 완료 시 To-Do 상태 COMPLETED

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지 작성해주세요 -->
- [x] 테스트 1
 ./gradlew test를 실행해서 전체 유닛/통합 테스트를 돌렸어요. H2 인메모리 DB를 쓰는 스프링 통합 테스트(StudyServiceTest, TodoServiceTest)가 포함되어 있어서 스터디/투두 생성과
  권한 흐름, 완료 로직까지 실제 JPA 트랜잭션 위에서 검증했습니다. 해당 명령 1회 수행해 모든 변경을 확인했습니다.


## 📸 스크린샷 (선택)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->


## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 테스트를 완료했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 리뷰어를 지정했습니다


## 📎 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added todo management system within studies: create todos with participant assignments, view todo lists and details, and mark todos complete with verification content.

* **Tests**
  * Added test coverage for todo creation and completion workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->